### PR TITLE
use multi-arch postgres image

### DIFF
--- a/config/00-init/03-db-deployment.yaml
+++ b/config/00-init/03-db-deployment.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       containers:
         - name: tekton-hub-db
-          image: postgres:13@sha256:260a98d976574b439712c35914fdcb840755233f79f3e27ea632543f78b7a21e
+          image: postgres:13
           resources:
             requests:
               cpu: 100m


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Currently postgres image(i.e `postgres:13@sha256:260a98d976574b439712c35914fdcb840755233f79f3e27ea632543f78b7a21e`) is going to run only in amd64. so we need to use multi-arch to work on different platforms.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/main/standards.md#principles) (if functionality changed/added)
- [ ] Run API Unit Tests, Lint Checks, API Design, Golden Files with `make api-check`
- [ ] Run UI Unit Tests, Lint Checks with `make ui-check`
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/main/CONTRIBUTING.md) for more details._
